### PR TITLE
Fix vertical alignment and copy changes

### DIFF
--- a/src/legacy/core_plugins/kibana/public/context/components/action_bar/action_bar.tsx
+++ b/src/legacy/core_plugins/kibana/public/context/components/action_bar/action_bar.tsx
@@ -88,7 +88,7 @@ export function ActionBar({
             iconType={type === 'predecessor' ? 'arrowUp' : 'arrowDown'}
             isLoading={isLoading}
             onClick={onLoadMoreClick}
-            size="s"
+            flush="right"
           >
             <FormattedMessage id="kbn.context.loadMoreDescription" defaultMessage="Load" />
           </EuiButtonEmpty>
@@ -122,12 +122,12 @@ export function ActionBar({
             {type === 'successor' ? (
               <FormattedMessage
                 id="kbn.context.olderDocumentsDescription"
-                defaultMessage="Older documents"
+                defaultMessage="older documents"
               />
             ) : (
               <FormattedMessage
                 id="kbn.context.newerDocumentsDescription"
-                defaultMessage="Newer documents"
+                defaultMessage="newer documents"
               />
             )}
           </EuiFormRow>


### PR DESCRIPTION
Aligns these 3 pieces vertically and presents them, grammatically, as a sentence:

<img width="406" alt="Screenshot 2019-09-05 12 59 12" src="https://user-images.githubusercontent.com/446285/64367867-a639b580-cfde-11e9-871d-4b64d8eb739d.png">
