### PR TITLE
Kertal pr 2020 01 13 painless playground suggestions

### DIFF
--- a/x-pack/legacy/plugins/painless_playground/common/constants.ts
+++ b/x-pack/legacy/plugins/painless_playground/common/constants.ts
@@ -7,3 +7,5 @@
 export const PLUGIN_ID = 'painless_playground';
 
 export const API_ROUTE_EXECUTE = '/api/painless_playground/execute';
+
+export const ADVANCED_SETTINGS_FLAG_NAME = 'devTools:enablePainlessPlayground';

--- a/x-pack/legacy/plugins/painless_playground/index.ts
+++ b/x-pack/legacy/plugins/painless_playground/index.ts
@@ -3,12 +3,13 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-
+import { i18n } from '@kbn/i18n';
 import { resolve } from 'path';
-import { PLUGIN_ID } from './common/constants';
+import { PLUGIN_ID, ADVANCED_SETTINGS_FLAG_NAME } from './common/constants';
 
 import { registerLicenseChecker } from './server/register_license_checker';
 import { registerExecuteRoute } from './server/register_execute_route';
+import { Legacy } from '../../../../kibana';
 
 export const painlessPlayground = (kibana: any) =>
   new kibana.Plugin({
@@ -24,7 +25,24 @@ export const painlessPlayground = (kibana: any) =>
     uiExports: {
       devTools: [resolve(__dirname, 'public/register')],
     },
-    init: (server: any) => {
+    init: (server: Legacy.Server) => {
+      // Register feature flag
+      server.newPlatform.setup.core.uiSettings.register({
+        [ADVANCED_SETTINGS_FLAG_NAME]: {
+          name: i18n.translate('kbn.advancedSettings.devTools.painlessPlaygroundTitle', {
+            defaultMessage: 'Painless Playground',
+          }),
+          description: i18n.translate(
+            'kbn.advancedSettings.devTools.painlessPlaygroundDescription',
+            {
+              defaultMessage: 'Enable experimental Painless Playground.',
+            }
+          ),
+          value: false,
+          category: ['Dev Tools'],
+        },
+      });
+
       registerLicenseChecker(server);
       registerExecuteRoute(server);
     },

--- a/x-pack/legacy/plugins/painless_playground/public/components/helpers.ts
+++ b/x-pack/legacy/plugins/painless_playground/public/components/helpers.ts
@@ -60,3 +60,16 @@ export function formatJson(json: any): string {
     return `Invalid JSON ${String(json)}`;
   }
 }
+
+export function formatExecutionError(json: object) {
+  if (json.script_stack && json.caused_by) {
+    return `Unhandled Exception ${json.caused_by.type}
+
+${json.caused_by.reason}
+
+Located at:
+${formatJson(json.script_stack)}
+`;
+  }
+  return formatJson(json);
+}

--- a/x-pack/legacy/plugins/painless_playground/public/components/painless_playground.tsx
+++ b/x-pack/legacy/plugins/painless_playground/public/components/painless_playground.tsx
@@ -18,6 +18,8 @@ import {
   EuiTabbedContent,
   EuiTitle,
   EuiIconTip,
+  EuiSpacer,
+  EuiPageContent,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { i18n } from '@kbn/i18n';
@@ -70,29 +72,31 @@ export function PainlessPlayground({
   );
 
   return (
-    <>
-      <EuiFlexGroup
-        className="consoleContainer"
-        gutterSize="none"
-        direction="column"
-        responsive={false}
-      >
-        <EuiFlexItem grow={false}>
-          <EuiTitle className="euiScreenReaderOnly">
-            <h1>
-              {i18n.translate('xpack.painless_playground.title', {
-                defaultMessage: 'Painless Playground',
-              })}
-            </h1>
-          </EuiTitle>
-          <EuiTabbedContent
-            size="s"
-            tabs={[
-              {
-                id: 'output',
-                name: 'Code',
-                content: (
-                  <EuiPanel>
+    <EuiFlexGroup
+      className="consoleContainer"
+      gutterSize="none"
+      direction="column"
+      responsive={false}
+    >
+      <EuiFlexItem grow={false}>
+        <EuiTitle className="euiScreenReaderOnly">
+          <h1>
+            {i18n.translate('xpack.painless_playground.title', {
+              defaultMessage: 'Painless Playground',
+            })}
+          </h1>
+        </EuiTitle>
+
+        <EuiTabbedContent
+          size="s"
+          tabs={[
+            {
+              id: 'output',
+              name: 'Code',
+              content: (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiPageContent>
                     <CodeEditor
                       languageId="painless"
                       height={250}
@@ -110,52 +114,98 @@ export function PainlessPlayground({
                     />
                     <EuiHorizontalRule margin="xs" />
                     {renderExecuteBtn()}
-                  </EuiPanel>
-                ),
-              },
-              {
-                id: 'request',
-                name: 'Request',
-                content: (
-                  <EuiPanel>
-                    <EuiCodeBlock language="json" paddingSize="s" isCopyable>
-                      {'POST _scripts/painless/_execute\n'}
-                      {formatJson(buildRequestPayloadPreview())}
-                    </EuiCodeBlock>
-                    <EuiHorizontalRule margin="xs" />
-                    {renderExecuteBtn()}
-                  </EuiPanel>
-                ),
-              },
-              {
-                id: 'settings',
-                name: 'Settings',
-                content: (
-                  <EuiPanel>
-                    <EuiForm data-test-subj="painlessPlayground">
-                      <EuiFormRow
-                        label={
-                          <FormattedMessage
-                            id="xpack.painless_playground.execution_context"
-                            defaultMessage="Execution Context"
-                          />
+                  </EuiPageContent>
+                </>
+              ),
+            },
+            {
+              id: 'request',
+              name: 'Request',
+              content: (
+                <EuiPanel>
+                  <EuiCodeBlock language="json" paddingSize="s" isCopyable>
+                    {'POST _scripts/painless/_execute\n'}
+                    {formatJson(buildRequestPayloadPreview())}
+                  </EuiCodeBlock>
+                  <EuiHorizontalRule margin="xs" />
+                  {renderExecuteBtn()}
+                </EuiPanel>
+              ),
+            },
+            {
+              id: 'settings',
+              name: 'Settings',
+              content: (
+                <EuiPanel>
+                  <EuiForm data-test-subj="painlessPlayground">
+                    <EuiFormRow
+                      label={
+                        <FormattedMessage
+                          id="xpack.painless_playground.execution_context"
+                          defaultMessage="Execution Context"
+                        />
+                      }
+                      fullWidth
+                    >
+                      <EuiSelect
+                        options={painlessContextOptions}
+                        value={context}
+                        onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                          setContext(e.target.value)
                         }
-                        fullWidth
-                      >
-                        <EuiSelect
-                          options={painlessContextOptions}
-                          value={context}
-                          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                            setContext(e.target.value)
+                      />
+                    </EuiFormRow>
+
+                    <EuiFormRow
+                      label={
+                        <FormattedMessage
+                          id="xpack.painless_playground.parametersLabel"
+                          defaultMessage="Parameters"
+                        />
+                      }
+                      fullWidth
+                      labelAppend={
+                        <EuiIconTip
+                          aria-label={i18n.translate(
+                            'xpack.painless_playground.helpIconAriaLabel',
+                            {
+                              defaultMessage: 'Help',
+                            }
+                          )}
+                          content={
+                            <FormattedMessage
+                              id="xpack.painless_playground.parametersHelp"
+                              defaultMessage="Enter JSON that's available as 'params' in the code"
+                            />
                           }
                         />
-                      </EuiFormRow>
+                      }
+                    >
+                      <div style={{ border: '1px solid #D3DAE6', padding: '3px' }}>
+                        <CodeEditor
+                          languageId="javascript"
+                          height={100}
+                          value={contextSetup.params}
+                          onChange={(value: string) => setContextSetup({ params: value })}
+                          options={{
+                            fontSize: 12,
+                            minimap: {
+                              enabled: false,
+                            },
+                            scrollBeyondLastLine: false,
+                            wordWrap: 'on',
+                            wrappingIndent: 'indent',
+                          }}
+                        />
+                      </div>
+                    </EuiFormRow>
 
+                    {['filter', 'score'].indexOf(context) !== -1 && (
                       <EuiFormRow
                         label={
                           <FormattedMessage
-                            id="xpack.painless_playground.parametersLabel"
-                            defaultMessage="Parameters"
+                            id="xpack.painless_playground.indexLabel"
+                            defaultMessage="Index"
                           />
                         }
                         fullWidth
@@ -169,8 +219,45 @@ export function PainlessPlayground({
                             )}
                             content={
                               <FormattedMessage
-                                id="xpack.painless_playground.parametersHelp"
-                                defaultMessage="Enter JSON that's available as 'params' in the code"
+                                id="xpack.painless_playground.indexHelp"
+                                defaultMessage="The name of an index containing a mapping that is compatible with the document being indexed."
+                              />
+                            }
+                          />
+                        }
+                      >
+                        <EuiFieldText
+                          fullWidth
+                          value={contextSetup.index || ''}
+                          onChange={e =>
+                            setContextSetup(
+                              Object.assign({}, contextSetup, { index: e.target.value })
+                            )
+                          }
+                        />
+                      </EuiFormRow>
+                    )}
+                    {['filter', 'score'].indexOf(context) !== -1 && (
+                      <EuiFormRow
+                        label={
+                          <FormattedMessage
+                            id="xpack.painless_playground.codeLabel"
+                            defaultMessage="Document"
+                          />
+                        }
+                        fullWidth
+                        labelAppend={
+                          <EuiIconTip
+                            aria-label={i18n.translate(
+                              'xpack.painless_playground.helpIconAriaLabel',
+                              {
+                                defaultMessage: 'Help',
+                              }
+                            )}
+                            content={
+                              <FormattedMessage
+                                id="xpack.painless_playground.documentHelp"
+                                defaultMessage="Enter document as JSON that's available as 'doc' in the code"
                               />
                             }
                           />
@@ -180,8 +267,10 @@ export function PainlessPlayground({
                           <CodeEditor
                             languageId="javascript"
                             height={100}
-                            value={contextSetup.params}
-                            onChange={(value: string) => setContextSetup({ params: value })}
+                            value={contextSetup.document}
+                            onChange={(value: string) =>
+                              setContextSetup(Object.assign({}, contextSetup, { document: value }))
+                            }
                             options={{
                               fontSize: 12,
                               minimap: {
@@ -194,133 +283,49 @@ export function PainlessPlayground({
                           />
                         </div>
                       </EuiFormRow>
-
-                      {['filter', 'score'].indexOf(context) !== -1 && (
-                        <EuiFormRow
-                          label={
-                            <FormattedMessage
-                              id="xpack.painless_playground.indexLabel"
-                              defaultMessage="Index"
-                            />
-                          }
-                          fullWidth
-                          labelAppend={
-                            <EuiIconTip
-                              aria-label={i18n.translate(
-                                'xpack.painless_playground.helpIconAriaLabel',
-                                {
-                                  defaultMessage: 'Help',
-                                }
-                              )}
-                              content={
-                                <FormattedMessage
-                                  id="xpack.painless_playground.indexHelp"
-                                  defaultMessage="The name of an index containing a mapping that is compatible with the document being indexed."
-                                />
-                              }
-                            />
-                          }
-                        >
-                          <EuiFieldText
-                            fullWidth
-                            value={contextSetup.index || ''}
-                            onChange={e =>
-                              setContextSetup(
-                                Object.assign({}, contextSetup, { index: e.target.value })
-                              )
-                            }
-                          />
-                        </EuiFormRow>
-                      )}
-                      {['filter', 'score'].indexOf(context) !== -1 && (
-                        <EuiFormRow
-                          label={
-                            <FormattedMessage
-                              id="xpack.painless_playground.codeLabel"
-                              defaultMessage="Document"
-                            />
-                          }
-                          fullWidth
-                          labelAppend={
-                            <EuiIconTip
-                              aria-label={i18n.translate(
-                                'xpack.painless_playground.helpIconAriaLabel',
-                                {
-                                  defaultMessage: 'Help',
-                                }
-                              )}
-                              content={
-                                <FormattedMessage
-                                  id="xpack.painless_playground.documentHelp"
-                                  defaultMessage="Enter document as JSON that's available as 'doc' in the code"
-                                />
-                              }
-                            />
-                          }
-                        >
-                          <div style={{ border: '1px solid #D3DAE6', padding: '3px' }}>
-                            <CodeEditor
-                              languageId="javascript"
-                              height={100}
-                              value={contextSetup.document}
-                              onChange={(value: string) =>
-                                setContextSetup(
-                                  Object.assign({}, contextSetup, { document: value })
-                                )
-                              }
-                              options={{
-                                fontSize: 12,
-                                minimap: {
-                                  enabled: false,
-                                },
-                                scrollBeyondLastLine: false,
-                                wordWrap: 'on',
-                                wrappingIndent: 'indent',
-                              }}
-                            />
-                          </div>
-                        </EuiFormRow>
-                      )}
-                      {renderExecuteBtn()}
-                    </EuiForm>
+                    )}
+                    {renderExecuteBtn()}
+                  </EuiForm>
+                </EuiPanel>
+              ),
+            },
+          ]}
+        />
+      </EuiFlexItem>
+      {response.error || response.result ? (
+        <EuiFlexItem>
+          <EuiTabbedContent
+            size="s"
+            tabs={[
+              {
+                id: 'output',
+                name: 'Output',
+                content: (
+                  <>
+                    <EuiSpacer size="s" />
+                    <EuiPanel>
+                      <EuiCodeBlock language="json" paddingSize="s" isCopyable>
+                        {response?.result ? response?.result : formatJson(response?.error)}
+                      </EuiCodeBlock>
+                    </EuiPanel>
+                  </>
+                ),
+              },
+              {
+                id: 'request',
+                name: 'Response',
+                content: (
+                  <EuiPanel>
+                    <EuiCodeBlock language="json" paddingSize="s" isCopyable>
+                      {formatJson(response)}
+                    </EuiCodeBlock>
                   </EuiPanel>
                 ),
               },
             ]}
           />
         </EuiFlexItem>
-        {response.error || response.result ? (
-          <EuiFlexItem>
-            <EuiTabbedContent
-              size="s"
-              tabs={[
-                {
-                  id: 'output',
-                  name: 'Output',
-                  content: (
-                    <EuiPanel>
-                      <EuiCodeBlock language="json" paddingSize="s" isCopyable>
-                        {response?.result ? response?.result : formatJson(response?.error)}
-                      </EuiCodeBlock>
-                    </EuiPanel>
-                  ),
-                },
-                {
-                  id: 'request',
-                  name: 'Response',
-                  content: (
-                    <EuiPanel>
-                      <EuiCodeBlock language="json" paddingSize="s" isCopyable>
-                        {formatJson(response)}
-                      </EuiCodeBlock>
-                    </EuiPanel>
-                  ),
-                },
-              ]}
-            />
-          </EuiFlexItem>
-        ) : null}
-      </EuiFlexGroup>
-    </>
+      ) : null}
+    </EuiFlexGroup>
   );
 }

--- a/x-pack/legacy/plugins/painless_playground/public/register.ts
+++ b/x-pack/legacy/plugins/painless_playground/public/register.ts
@@ -10,6 +10,7 @@ import { xpackInfo } from 'plugins/xpack_main/services/xpack_info';
 import { npSetup, npStart } from 'ui/new_platform';
 import { registerPainless } from './register_painless';
 import { FeatureCatalogueCategory } from '../../../../../src/plugins/home/public';
+import { ADVANCED_SETTINGS_FLAG_NAME } from '../common/constants';
 
 npSetup.plugins.home.featureCatalogue.register({
   id: 'painless_playground',
@@ -25,6 +26,11 @@ npSetup.plugins.home.featureCatalogue.register({
   category: FeatureCatalogueCategory.ADMIN,
 });
 
+npSetup.core.uiSettings.get$(ADVANCED_SETTINGS_FLAG_NAME, false).subscribe(value => {
+  // eslint-disable-next-line
+  console.log('use this to figure out whether we should register', value);
+});
+
 npSetup.plugins.dev_tools.register({
   order: 7,
   title: i18n.translate('xpack.painless_playground.displayName', {
@@ -33,21 +39,22 @@ npSetup.plugins.dev_tools.register({
   id: 'painless_playground',
   enableRouting: false,
   disabled: false,
-  tooltipContent: xpackInfo.get('features.painless_playground.message'),
+  tooltipContent: xpackInfo.get('features.painlessPlayground.message'),
   async mount(context, { element }) {
     registerPainless();
-    /**
+
     const licenseCheck = {
-      showPage: xpackInfo.get('features.painless_playground.enableLink'),
-      message: xpackInfo.get('features.painless_playground.message'),
+      showPage: xpackInfo.get('features.painlessPlayground.enableLink'),
+      message: xpackInfo.get('features.painlessPlayground.message'),
     };
 
     if (!licenseCheck.showPage) {
       npStart.core.notifications.toasts.addDanger(licenseCheck.message);
       window.location.hash = '/dev_tools';
       return () => {};
-    }**/
+    }
+
     const { renderApp } = await import('./render_app');
-    return renderApp(element, npStart);
+    return renderApp(element, npStart.core);
   },
 });

--- a/x-pack/legacy/plugins/painless_playground/public/render_app.tsx
+++ b/x-pack/legacy/plugins/painless_playground/public/render_app.tsx
@@ -5,19 +5,22 @@
  */
 
 import React from 'react';
+import { CoreStart } from 'kibana/public';
 import { render, unmountComponentAtNode } from 'react-dom';
 import { PainlessPlayground } from './components/painless_playground';
 import { createKibanaReactContext } from '../../../../../src/plugins/kibana_react/public';
 import { executeCode } from './lib/execute_code';
 
-export function renderApp(element: any, npStart: any) {
+export function renderApp(element: any, { http, i18n, uiSettings }: CoreStart) {
   const { Provider: KibanaReactContextProvider } = createKibanaReactContext({
-    uiSettings: npStart.core.uiSettings,
+    uiSettings,
   });
   render(
-    <KibanaReactContextProvider>
-      <PainlessPlayground executeCode={payload => executeCode(npStart.core.http, payload)} />
-    </KibanaReactContextProvider>,
+    <i18n.Context>
+      <KibanaReactContextProvider>
+        <PainlessPlayground executeCode={payload => executeCode(http, payload)} />
+      </KibanaReactContextProvider>
+    </i18n.Context>,
     element
   );
   return () => unmountComponentAtNode(element);


### PR DESCRIPTION
Hey @kertal !

I've created this PR to help with getting Painless Playground more ready for merging into master.

It contains a number of changes (none of which you have to accept!) that I think would help:

- See use of `uiSettings` both client and server side for registering a feature flag
- See update to public `register.ts`, kibana does a thing where it takes keys from snake-case to camel-case which is what was causing issues for detecting the presence of x-pack
- I added use of `i18n.Context` as there were console errors about this
- I've changed some of the layout (most of the UI changes are in the second commit, so we can just cherry pick the first if you don't agree with them).

I'll also leave an early review of other things I've spotted.

These changes are not completed, so the feature flag is not actually implemented for preventing rendering the application - also I think more UI changes can be made before committing. See my comment on your PR.