### PR TITLE
Improve Expanded Document flyout design

### DIFF
--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
@@ -29,6 +29,7 @@ import {
   EuiLink,
   EuiPortal,
   EuiTitle,
+  EuiButtonEmpty,
 } from '@elastic/eui';
 import { DocViewer } from '../doc_viewer/doc_viewer';
 import { IndexPattern } from '../../../kibana_services';
@@ -67,40 +68,44 @@ export const DiscoverGridFlyout = function DiscoverGridInner({
             <EuiFlexItem>
               <EuiTitle className="dscTable__flyoutHeader">
                 <h2>
-                  <EuiIcon type="folderOpen" size="l" />{' '}
+                  <EuiIcon type="expand" size="m" />{' '}
                   {i18n.translate('discover.grid.tableRow.detailHeading', {
                     defaultMessage: 'Expanded document',
                   })}
                 </h2>
               </EuiTitle>
             </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiFlexGroup justifyContent="flexEnd">
-                {indexPattern.isTimeBased() && (
-                  <EuiFlexItem grow={false}>
-                    <EuiLink href={getContextAppHref ? getContextAppHref(hit._id) : ''}>
-                      {i18n.translate('discover.grid.tableRow.viewSurroundingDocumentsLinkText', {
-                        defaultMessage: 'View surrounding documents',
-                      })}
-                    </EuiLink>
-                  </EuiFlexItem>
-                )}
-                <EuiFlexItem grow={false}>
-                  <EuiLink
-                    href={`#/doc/${indexPattern.id}/${hit._index}?id=${encodeURIComponent(
-                      hit._id as string
-                    )}`}
-                  >
-                    {i18n.translate('discover.grid.tableRow.viewSingleDocumentLinkText', {
-                      defaultMessage: 'View single document',
-                    })}
-                  </EuiLink>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>
+          <EuiFlexGroup direction="column" gutterSize="none" alignItems="flexEnd">
+            {indexPattern.isTimeBased() && (
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty
+                  size="xs"
+                  iconType="documents"
+                  href={getContextAppHref ? getContextAppHref(hit._id) : ''}
+                >
+                  {i18n.translate('discover.grid.tableRow.viewSurroundingDocumentsLinkText', {
+                    defaultMessage: 'View surrounding documents',
+                  })}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            )}
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                size="xs"
+                iconType="document"
+                href={`#/doc/${indexPattern.id}/${hit._index}?id=${encodeURIComponent(
+                  hit._id as string
+                )}`}
+              >
+                {i18n.translate('discover.grid.tableRow.viewSingleDocumentLinkText', {
+                  defaultMessage: 'View single document',
+                })}
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
           <DocViewer
             hit={hit}
             columns={columns}

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
@@ -26,7 +26,6 @@ import {
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiIcon,
-  EuiLink,
   EuiPortal,
   EuiTitle,
   EuiButtonEmpty,

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_view_button.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_view_button.tsx
@@ -32,7 +32,7 @@ export const ViewButton = ({ rowIndex }: { rowIndex: number }) => {
       onClick={() => setViewed(rowIndex)}
       className="dscTable__buttonToggle"
     >
-      <EuiIcon size="s" type={viewed === rowIndex ? 'eyeClosed' : 'eye'} />
+      <EuiIcon size="s" type={viewed === rowIndex ? 'expandMini' : 'expand'} />
     </button>
   );
 };

--- a/src/plugins/discover/public/application/components/table/table_row.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row.tsx
@@ -67,26 +67,6 @@ export function DocViewTableRow({
 
   return (
     <tr key={field} data-test-subj={`tableDocViewRow-${field}`}>
-      {typeof onFilter === 'function' && (
-        <td className="kbnDocViewer__buttons">
-          <DocViewTableRowBtnFilterAdd
-            disabled={!fieldMapping || !fieldMapping.filterable}
-            onClick={() => onFilter(fieldMapping, valueRaw, '+')}
-          />
-          <DocViewTableRowBtnFilterRemove
-            disabled={!fieldMapping || !fieldMapping.filterable}
-            onClick={() => onFilter(fieldMapping, valueRaw, '-')}
-          />
-          {typeof onToggleColumn === 'function' && (
-            <DocViewTableRowBtnToggleColumn active={isColumnActive} onClick={onToggleColumn} />
-          )}
-          <DocViewTableRowBtnFilterExists
-            disabled={!fieldMapping || !fieldMapping.filterable}
-            onClick={() => onFilter('_exists_', field, '+')}
-            scripted={fieldMapping && fieldMapping.scripted}
-          />
-        </td>
-      )}
       <td className="kbnDocViewer__field">
         <FieldName
           fieldName={field}
@@ -112,6 +92,26 @@ export function DocViewTableRow({
           dangerouslySetInnerHTML={{ __html: value as string }}
         />
       </td>
+      {typeof onFilter === 'function' && (
+        <td className="kbnDocViewer__buttons">
+          <DocViewTableRowBtnFilterAdd
+            disabled={!fieldMapping || !fieldMapping.filterable}
+            onClick={() => onFilter(fieldMapping, valueRaw, '+')}
+          />
+          <DocViewTableRowBtnFilterRemove
+            disabled={!fieldMapping || !fieldMapping.filterable}
+            onClick={() => onFilter(fieldMapping, valueRaw, '-')}
+          />
+          {typeof onToggleColumn === 'function' && (
+            <DocViewTableRowBtnToggleColumn active={isColumnActive} onClick={onToggleColumn} />
+          )}
+          <DocViewTableRowBtnFilterExists
+            disabled={!fieldMapping || !fieldMapping.filterable}
+            onClick={() => onFilter('_exists_', field, '+')}
+            scripted={fieldMapping && fieldMapping.scripted}
+          />
+        </td>
+      )}
     </tr>
   );
 }

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_add.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_add.tsx
@@ -49,7 +49,7 @@ export function DocViewTableRowBtnFilterAdd({ onClick, disabled = false }: Props
         data-test-subj="addInclusiveFilterButton"
         disabled={disabled}
         onClick={onClick}
-        iconType={'magnifyWithPlus'}
+        iconType={'plusInCircle'}
         iconSize={'s'}
       />
     </EuiToolTip>

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_exists.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_exists.tsx
@@ -61,7 +61,7 @@ export function DocViewTableRowBtnFilterExists({
         className="kbnDocViewer__actionButton"
         data-test-subj="addExistsFilterButton"
         disabled={disabled}
-        iconType={'indexOpen'}
+        iconType={'filter'}
         iconSize={'s'}
       />
     </EuiToolTip>

--- a/src/plugins/discover/public/application/components/table/table_row_btn_filter_remove.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_filter_remove.tsx
@@ -49,7 +49,7 @@ export function DocViewTableRowBtnFilterRemove({ onClick, disabled = false }: Pr
         data-test-subj="removeInclusiveFilterButton"
         disabled={disabled}
         onClick={onClick}
-        iconType={'magnifyWithMinus'}
+        iconType={'minusInCircle'}
         iconSize={'s'}
       />
     </EuiToolTip>

--- a/src/plugins/discover/public/application/components/table/table_row_btn_toggle_column.tsx
+++ b/src/plugins/discover/public/application/components/table/table_row_btn_toggle_column.tsx
@@ -37,7 +37,7 @@ export function DocViewTableRowBtnToggleColumn({ onClick, active, disabled = fal
         className="kbnDocViewer__actionButton"
         data-test-subj="toggleColumnButton"
         disabled
-        iconType={'tableOfContents'}
+        iconType={'listAdd'}
         iconSize={'s'}
       />
     );
@@ -59,7 +59,7 @@ export function DocViewTableRowBtnToggleColumn({ onClick, active, disabled = fal
         onClick={onClick}
         className="kbnDocViewer__actionButton"
         data-test-subj="toggleColumnButton"
-        iconType={'tableOfContents'}
+        iconType={'listAdd'}
         iconSize={'s'}
       />
     </EuiToolTip>


### PR DESCRIPTION
## Summary

Some improvements to the Expanded Doc Flyout as seen below:
<img width="1282" alt="image 14" src="https://user-images.githubusercontent.com/4016496/91673746-6e2e5b00-eaea-11ea-8590-353e91b6ad5d.png">

Pending for the future:

1. In the flyout, I would like the icon for "toggle column" to be `listAdd` if the field is not on the grid yet and be `list` if it is there.
2. Clicking on the "expand row" icon on the datagrid show close the flyout if it is already open.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

