### PR TITLE
[Discover] Fix datagrid positioning in fullscreen

### DIFF
--- a/src/core/public/chrome/ui/header/_index.scss
+++ b/src/core/public/chrome/ui/header/_index.scss
@@ -1,7 +1,9 @@
 @include euiHeaderAffordForFixed;
 
-.euiDataGrid__restrictBody .chrHeaderWrapper {
-  display: none;
+.euiDataGrid__restrictBody {
+  .headerGlobalNav {
+    display: none;
+  }
 }
 
 .chrHeaderHelpMenu__version {

--- a/src/plugins/discover/public/application/_discover.scss
+++ b/src/plugins/discover/public/application/_discover.scss
@@ -1,3 +1,9 @@
+body.euiDataGrid__restrictBody {
+  .application {
+    z-index: $euiZLevel1;
+  }
+}
+
 .dscAppWrapper {
   display: flex;
   flex-direction: column;

--- a/src/plugins/discover/public/application/_discover.scss
+++ b/src/plugins/discover/public/application/_discover.scss
@@ -1,9 +1,3 @@
-body.euiDataGrid__restrictBody {
-  .application {
-    z-index: $euiZLevel1;
-  }
-}
-
 .dscAppWrapper {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

@kertal this fixes the issue but not 100% sure it is clean, is there a way to target just Discover?

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

