### PR TITLE
Layout and responsive adjustments

### DIFF
--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
@@ -82,3 +82,10 @@
 .dscDiscoverGrid__descriptionListDescription {
   word-break: normal !important;
 }
+
+@include euiBreakpoint('xs', 's', 'm') {
+  // EUI issue to hide 'of' text https://github.com/elastic/eui/issues/4654
+  .dscTable__flyoutDocumentNavigation .euiPagination__compressedText {
+    display: none;
+  }
+}

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid.scss
@@ -40,6 +40,10 @@
   white-space: nowrap;
 }
 
+.dscTable__flyoutDocumentNavigation {
+  justify-content: end;
+}
+
 // We only truncate if the cell is not a control column.
 .euiDataGridHeader {
   .euiDataGridHeaderCell__content {

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
@@ -152,20 +152,18 @@ export function DiscoverGridFlyout({
               </EuiFlexItem>
             )}
             {activePage !== -1 && (
-              <EuiHideFor sizes={['xs', 's', 'm']}>
-                <EuiFlexItem>
-                  <EuiPagination
-                    aria-label={i18n.translate('discover.grid.flyout.documentNavigation', {
-                      defaultMessage: 'Document navigation',
-                    })}
-                    pageCount={pageCount}
-                    activePage={activePage}
-                    onPageClick={setPage}
-                    className="dscTable__flyoutDocumentNavigation"
-                    compressed
-                  />
-                </EuiFlexItem>
-              </EuiHideFor>
+              <EuiFlexItem>
+                <EuiPagination
+                  aria-label={i18n.translate('discover.grid.flyout.documentNavigation', {
+                    defaultMessage: 'Document navigation',
+                  })}
+                  pageCount={pageCount}
+                  activePage={activePage}
+                  onPageClick={setPage}
+                  className="dscTable__flyoutDocumentNavigation"
+                  compressed
+                />
+              </EuiFlexItem>
             )}
           </EuiFlexGroup>
         </EuiFlyoutHeader>

--- a/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
+++ b/src/plugins/discover/public/application/components/discover_grid/discover_grid_flyout.tsx
@@ -117,6 +117,7 @@ export function DiscoverGridFlyout({
               <EuiButtonEmpty
                 size="xs"
                 iconType="document"
+                flush="left"
                 href={services.addBasePath(
                   `#/doc/${indexPattern.id}/${hit._index}?id=${encodeURIComponent(
                     hit._id as string
@@ -130,10 +131,11 @@ export function DiscoverGridFlyout({
               </EuiButtonEmpty>
             </EuiFlexItem>
             {indexPattern.isTimeBased() && indexPattern.id && (
-              <EuiFlexItem>
+              <EuiFlexItem grow={false}>
                 <EuiButtonEmpty
                   size="xs"
                   iconType="documents"
+                  flush="left"
                   href={getContextUrl(
                     hit._id,
                     indexPattern.id,
@@ -150,17 +152,20 @@ export function DiscoverGridFlyout({
               </EuiFlexItem>
             )}
             {activePage !== -1 && (
-              <EuiFlexItem grow={false}>
-                <EuiPagination
-                  aria-label={i18n.translate('discover.grid.flyout.documentNavigation', {
-                    defaultMessage: 'Document navigation',
-                  })}
-                  pageCount={pageCount}
-                  activePage={activePage}
-                  onPageClick={setPage}
-                  compressed
-                />
-              </EuiFlexItem>
+              <EuiHideFor sizes={['xs', 's', 'm']}>
+                <EuiFlexItem>
+                  <EuiPagination
+                    aria-label={i18n.translate('discover.grid.flyout.documentNavigation', {
+                      defaultMessage: 'Document navigation',
+                    })}
+                    pageCount={pageCount}
+                    activePage={activePage}
+                    onPageClick={setPage}
+                    className="dscTable__flyoutDocumentNavigation"
+                    compressed
+                  />
+                </EuiFlexItem>
+              </EuiHideFor>
             )}
           </EuiFlexGroup>
         </EuiFlyoutHeader>


### PR DESCRIPTION
## Summary

This design PR includes the following adjustments:

1. Similar to the 'View' label, hide the pagination on smaller screen sizes
2. Align the pagination to the right end of the row
3. Set the left two buttons to flush left (removes extra spacing when 'View' is not present; tightens up general spacing)