### PR TITLE
Fix user filter field input getting stuck in invalid state.

### DIFF
--- a/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/add_filter.tsx
+++ b/src/platform/plugins/shared/data_view_management/public/components/edit_index_pattern/source_filters_table/components/add_filter/add_filter.tsx
@@ -44,6 +44,7 @@ export const AddFilter = ({ onAddFilter }: AddFilterProps) => {
     try {
       // test value is not important, just that the created regex is able to compile
       makeRegEx(value).test('');
+      setIsInvalid(false);
     } catch (e) {
       setIsInvalid(true);
       return;


### PR DESCRIPTION
## Summary

- Resolve feedback about user filter field input getting stuck in invalid state.

<!--
### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...


-->
